### PR TITLE
Fix: Corregir errores de namespace en archivos PHP

### DIFF
--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace App\Http\Middleware;

--- a/app/Models/Canje.php
+++ b/app/Models/Canje.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace App\Models;

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace App\Models;

--- a/app/Models/Localidad.php
+++ b/app/Models/Localidad.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace App\Models;

--- a/app/Models/Ruta.php
+++ b/app/Models/Ruta.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace App\Models;

--- a/app/Models/Tienda.php
+++ b/app/Models/Tienda.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace App\Models;


### PR DESCRIPTION
## 🐛 Corrección de Errores de Namespace

### Problema
La aplicación Laravel estaba generando errores fatales de PHP:
```
Fatal error: Namespace declaration statement has to be the very first statement 
or after any declare call in the script
```

### Causa Raíz
Los archivos PHP tenían un carácter de salto de línea (`\n` / `0x0a`) **antes** de la etiqueta de apertura `<?php`, lo que violaba la regla de PHP que requiere que la declaración `namespace` sea la primera instrucción después de `<?php`.

### Archivos Corregidos
- ✅ `app/Models/Collection.php`
- ✅ `app/Http/Middleware/CheckRole.php`
- ✅ `app/Models/Ruta.php`
- ✅ `app/Models/Localidad.php`
- ✅ `app/Models/Tienda.php`
- ✅ `app/Models/Canje.php`

### Solución Aplicada
Se eliminó el carácter de salto de línea inicial en cada archivo, asegurando que `<?php` sea el primer contenido del archivo.

**Antes:**
```
[salto de línea]
<?php

namespace App\Models;
```

**Después:**
```
<?php

namespace App\Models;
```

### Impacto
- ✅ Elimina los errores fatales de PHP
- ✅ Permite que la aplicación se ejecute correctamente en XAMPP
- ✅ Cumple con los estándares de codificación de PHP/Laravel

### Testing
Se verificó mediante hexdump que todos los archivos ahora comienzan correctamente con `0x3c` (carácter `<`).

---
**Nota:** Esta corrección es crítica para el funcionamiento de la aplicación y debe ser fusionada antes de continuar con el desarrollo.